### PR TITLE
`README.md` Type?

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each sample is accompanied by its own documentation detailing functionality and 
 ### Cloning Repositories
 
 ```bash
-git clone --recursive --shallow-submodules https://github.com/nvpro-samples/nvpro_core.git
+git clone --recursive --shallow-submodules https://github.com/nvpro-samples/nvpro_core2.git
 git clone https://github.com/nvpro-samples/vk_mini_samples.git
 ```
 


### PR DESCRIPTION
I’ve been benefiting a lot from this repository — thank you for providing it.

While setting it up, I noticed what seems to be a typo. From looking at the CMake files, it seems like you intended to refer to core2, so I thought it might be helpful to suggest a correction to the README. I’m submitting this PR for your consideration.